### PR TITLE
settings fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ https://github.com/iron-meteor/iron-router/issues/1192
 You can add the following settings in your **Meteor Settings Config json File**:
 ```json
 {
-	'spiderable2': {
-		'timeout': 1000,
-		'port': 3000,
-		'verbose': false
+	"spiderable2": {
+		"timeout": 1000,
+		"port": 3000,
+		"verbose": false
 	}
 }
 ```


### PR DESCRIPTION
meteor complains about single quotes in config

``` bash
=> Meteor server restarted
=> Errors prevented startup:                  

   While preparing to run:
   settings.json: parse error reading settings file

=> Your application has errors. Waiting for file change.
```
